### PR TITLE
Refactor Hero section into React component

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -1,0 +1,49 @@
+export default function Hero({ imagePath }) {
+  return (
+    <>
+    <section className="h-100-section hero bg-hero white-letters">
+      <div className="overlay strong bring-to-front"></div>
+
+      <div className="container h-100 bring-to-front">
+        <div className="row h-100 justify-content-center align-items-center">
+          <div className="col-lg-8 center">
+            <h1 className="mb-0">
+              Education Reimagined
+            </h1>
+            <h3 className="mt-2 mb-4">
+              Forget the educational paradigm you've known all your life. We're reinventing education, and your family can be a part
+              of it.
+            </h3>
+          </div>
+          <div className="col-sm-12 center">
+            <div className="buttons">
+              <a href="https://vimeo.com/83651159" data-lity className="button white">
+                Watch video <i className="fa fa-play ml"></i>
+              </a>
+              <a className="button quaternary" href="{{ 'apply' | relative_url }}">Apply Now</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <style jsx>
+      {`
+        .bg-hero {
+          background: no-repeat center 30%;
+          background-size: cover;
+          padding-top: 15rem;
+          padding-bottom: 12rem;
+          background-image: url(${imagePath});
+        }
+        .hero {
+          padding: 8rem 0;
+          min-height: 450px;
+          display: flex;
+          align-items: center;
+          text-align: center;
+        }
+      `}
+    </style>
+    </>
+  )
+} 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import Layout, { siteTitle } from '../components/layout'
+import Hero from '../components/hero'
 
 export default function HomePage() {
   return (
@@ -8,32 +9,7 @@ export default function HomePage() {
         <title>{siteTitle}</title>
       </Head>
 
-      <section className="h-100-section hero bg-hero white-letters">
-        <div className="overlay strong bring-to-front"></div>
-
-        <div className="container h-100 bring-to-front">
-          <div className="row h-100 justify-content-center align-items-center">
-            <div className="col-lg-8 center">
-              <h1 className="mb-0">
-                Education Reimagined
-              </h1>
-              <h3 className="mt-2 mb-4">
-                Forget the educational paradigm you've known all your life. We're reinventing education, and your family can be a part
-                of it.
-              </h3>
-            </div>
-            <div className="col-sm-12 center">
-              <div className="buttons">
-                <a href="https://vimeo.com/83651159" data-lity className="button white">
-                  Watch video <i className="fa fa-play ml"></i>
-                </a>
-                <a className="button quaternary" href="{{ 'apply' | relative_url }}">Apply Now</a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
+      <Hero imagePath={"images/bg-hero-home.jpg"} />
       <section>
         <div className="container">
           <div className="row justify-content-center">

--- a/styles/pages.scss
+++ b/styles/pages.scss
@@ -55,22 +55,6 @@ section {
   min-height: 100vh !important;
 }
 
-  .bg-hero {
-    background: no-repeat center 30%;
-    background-size: cover;
-    padding-top: 15rem;
-    padding-bottom: 12rem;
-    background-image: url(../public/images/bg-hero-home.jpg);
-  }
-
-  .hero {
-    padding: 8rem 0;
-    min-height: 450px;
-    display: flex;
-    align-items: center;
-    text-align: center;
-  }
-
 .section-title {
   margin-bottom: 2rem;
 }


### PR DESCRIPTION
## Why are we making this change?

We are refactoring the HTML Hero section into a React component to (1) make it more flexible and reusable throughout our application and (2) to make our Pages components (in this case, pages/index.js) more organized and easier to read.

Since this website was previously built as a Jekyll site, the refactoring of this component is part of the process of converting HTML/Liquid partials into React/JSX components to take advantage of their encapsulation and reusability throughout the new application.

## What's changing? Brief summary of what changed.
The main hero section of the homepage (pages/index.js) is being replaced with a component Hero component, passing in an imagePath prop.

The imagePath prop is then used in the styled-jsx block to provide the right background image for a particular instance of the new Hero component so that it can be used on different pages with different images.

The code for this component has been moved to its own file in components/Hero.js. The associated styles for the hero section have been moved from the pages.scss file to components/Hero.js as well.

## Screenshots / demo

<img width="1434" alt="hero-component" src="https://user-images.githubusercontent.com/37816105/112387873-b4d2e500-8cc8-11eb-9156-d20ef9e96c13.png">

## Areas of interest

This is not an exhaustive refactoring. Instead, it provides an example of how existing code can be turned into React components with their own scoped styles. 

One key aspect to keep in mind is that, as of now, SCSS provides nesting of CSS properties but styled-jsx does not. Using SCSS modules is, most likely, a better solution.